### PR TITLE
Refresh landing page with 2026 yellow-green visual style

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,47 +1,203 @@
-
 <!DOCTYPE html>
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ケモ耳SRPGアドベンチャー - スタート</title>
+    <title>ケモ耳SRPGアドベンチャー | LP 2026</title>
     <style>
+        :root {
+            --bg: #06110a;
+            --card: rgba(13, 28, 14, 0.72);
+            --line: rgba(198, 255, 0, 0.25);
+            --text: #f7ffe9;
+            --muted: #d4e9be;
+            --green: #8ce041;
+            --yellow: #ffe94a;
+            --accent: linear-gradient(120deg, #ffe94a 0%, #8ce041 55%, #34c87d 100%);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
         body {
             margin: 0;
-            padding: 0;
-            display: flex;
-            height: 100vh;
+            min-height: 100vh;
+            font-family: "Inter", "Noto Sans JP", "Hiragino Kaku Gothic ProN", sans-serif;
+            color: var(--text);
+            background:
+                radial-gradient(circle at 8% 10%, rgba(255, 233, 74, 0.3), transparent 42%),
+                radial-gradient(circle at 88% 4%, rgba(140, 224, 65, 0.26), transparent 34%),
+                radial-gradient(circle at 70% 82%, rgba(52, 200, 125, 0.18), transparent 35%),
+                var(--bg);
+            overflow-x: hidden;
+        }
+
+        .noise {
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            background-image: radial-gradient(rgba(255,255,255,0.06) 0.6px, transparent 0.6px);
+            background-size: 3px 3px;
+            opacity: .18;
+            mix-blend-mode: soft-light;
+        }
+
+        .wrapper {
+            width: min(1120px, 92vw);
+            margin: 32px auto;
+        }
+
+        .hero {
+            border: 1px solid var(--line);
+            background: linear-gradient(140deg, rgba(17, 37, 16, 0.82), rgba(8, 15, 11, 0.95));
+            backdrop-filter: blur(12px);
+            border-radius: 24px;
+            padding: clamp(24px, 4vw, 56px);
+            box-shadow: 0 30px 100px rgba(0, 0, 0, 0.45);
+        }
+
+        .label {
+            display: inline-flex;
             align-items: center;
-            justify-content: center;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            font-family: 'Arial', sans-serif;
-            color: white;
-            text-align: center;
+            gap: 8px;
+            padding: 7px 12px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 233, 74, 0.45);
+            color: #fff8ba;
+            background: rgba(255, 233, 74, 0.1);
+            font-size: 13px;
+            letter-spacing: .04em;
+            margin-bottom: 16px;
         }
-        .start-container {
+
+        h1 {
+            margin: 0;
+            font-size: clamp(34px, 6vw, 64px);
+            line-height: 1.08;
+            letter-spacing: -0.03em;
+            text-wrap: balance;
+        }
+
+        .grad-text {
+            background: var(--accent);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+
+        .lead {
+            margin-top: 18px;
+            max-width: 62ch;
+            color: var(--muted);
+            line-height: 1.75;
+            font-size: clamp(15px, 2vw, 18px);
+        }
+
+        .cta-area {
+            margin-top: 28px;
             display: flex;
-            flex-direction: column;
-            gap: 20px;
+            gap: 14px;
+            flex-wrap: wrap;
         }
-        .start-btn {
-            padding: 10px 30px;
-            font-size: 20px;
+
+        .btn {
             border: none;
-            border-radius: 5px;
             cursor: pointer;
-            color: white;
-            background: rgba(255,255,255,0.2);
-            transition: background 0.3s ease;
+            padding: 13px 24px;
+            border-radius: 12px;
+            font-weight: 700;
+            font-size: 15px;
+            text-decoration: none;
+            transition: transform .2s ease, box-shadow .2s ease, filter .2s ease;
         }
-        .start-btn:hover {
-            background: rgba(255,255,255,0.3);
+
+        .btn-primary {
+            color: #1f2b00;
+            background: var(--accent);
+            box-shadow: 0 8px 35px rgba(170, 243, 63, 0.35);
+        }
+
+        .btn-secondary {
+            color: var(--text);
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255,255,255,0.22);
+        }
+
+        .btn:hover {
+            transform: translateY(-1px);
+            filter: brightness(1.03);
+        }
+
+        .grid {
+            margin-top: 30px;
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 14px;
+        }
+
+        .feature {
+            background: var(--card);
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 14px;
+            padding: 16px;
+        }
+
+        .feature strong {
+            display: block;
+            margin-bottom: 8px;
+            color: #eeffbf;
+        }
+
+        .feature p {
+            margin: 0;
+            color: var(--muted);
+            font-size: 14px;
+            line-height: 1.55;
+        }
+
+        @media (max-width: 820px) {
+            .grid {
+                grid-template-columns: 1fr;
+            }
         }
     </style>
 </head>
 <body>
-    <div class="start-container">
-        <h1>ケモ耳SRPGアドベンチャー</h1>
-        <button class="start-btn" onclick="location.href='stage_select.html'">ゲーム開始</button>
-    </div>
+    <div class="noise"></div>
+
+    <main class="wrapper">
+        <section class="hero">
+            <div class="label">2026 NEW VISUAL LANDING PAGE</div>
+            <h1>
+                ケモ耳SRPGアドベンチャーを<br>
+                <span class="grad-text">黄×緑のネオ・ファンタジー</span>へ。
+            </h1>
+            <p class="lead">
+                戦略・育成・ストーリーを横断する、没入型SRPG体験。2026年らしいグラスモーフィズムと
+                ネオンアクセントで、ひと目で世界観が伝わるLPに刷新しました。
+            </p>
+
+            <div class="cta-area">
+                <a class="btn btn-primary" href="stage_select.html">ゲーム開始</a>
+                <a class="btn btn-secondary" href="game1.html">バトル体験へ</a>
+            </div>
+
+            <div class="grid">
+                <article class="feature">
+                    <strong>Instant Strategy Loop</strong>
+                    <p>ステージ選択から戦闘まで最短導線。テンポ重視の導入で離脱を抑えます。</p>
+                </article>
+                <article class="feature">
+                    <strong>Character-First Story</strong>
+                    <p>ケモ耳キャラの魅力を主軸に、感情移入しやすいコピー＆UIバランスに最適化。</p>
+                </article>
+                <article class="feature">
+                    <strong>Future-ready Design</strong>
+                    <p>黄と緑を基調にした高視認コントラストで、2026年トレンドの質感に統一。</p>
+                </article>
+            </div>
+        </section>
+    </main>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Update the minimal start screen into a modern landing page that reads as a 2026 visual direction using yellow and green as primary colors.
- Increase conversion-focused structure by adding a hero, clear CTAs, and feature highlights to reduce drop-off at first touch.
- Apply a contemporary aesthetic (neon-gradient accents and glassmorphism) to align the UI with current design trends.

### Description
- Rewrote `index.html` to replace the simple start screen with a styled LP including a hero section, label, headline, lead copy, CTA area, and a 3-column feature grid.
- Introduced CSS variables and new styles for a dark yellow/green theme, layered radial gradients, subtle noise overlay, and a glassmorphism-inspired hero container.
- Added two CTA paths linking to `stage_select.html` and `game1.html`, plus responsive rules that collapse the feature grid to one column on small screens.
- Updated typography, spacing, button styles (`.btn`, `.btn-primary`, `.btn-secondary`), and page `<title>` to reflect the 2026 LP identity.

### Testing
- Ran `git status --short` to verify changes were staged and visible, which succeeded.
- Inspected the modified file with `nl -ba index.html | sed -n '1,260p'` to confirm markup and styles, which succeeded.
- Committed the change using `git add index.html && git commit -m "Refresh LP with yellow-green 2026 visual style"` and created the PR metadata with `make_pr`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff444b7284832aaa908c6f6ddf3b69)